### PR TITLE
Add new function: fromDoubleRounded

### DIFF
--- a/csharp/EPAM.Deltix.DFP.Test/Decimal64Test.cs
+++ b/csharp/EPAM.Deltix.DFP.Test/Decimal64Test.cs
@@ -1251,7 +1251,7 @@ namespace EPAM.Deltix.DFP.Test
 				new ToStringData(Decimal64.Zero, "0", "0.0")
 			};
 
-			foreach(var testCase in testCases)
+			foreach (var testCase in testCases)
 			{
 				var testValue = testCase.TestValue;
 				Assert.AreEqual(testCase.NormalOut, testValue.ToString());
@@ -1270,6 +1270,45 @@ namespace EPAM.Deltix.DFP.Test
 		}
 
 		readonly int N = 5000000;
+
+
+		[Test]
+		public void TestFromDoubleRoundedShortAlias()
+		{
+			Random random = new Random();
+			for (int i = 0; i < N; ++i)
+			{
+				double inputValue = random.NextDouble() * random.Next(-20, 20);
+				var refValue = Decimal64.FromDouble(inputValue).Round(
+					Decimal64.FromDoubleRoundedDefaultPrecision,
+					Decimal64.FromDoubleRoundedDefaultRounding);
+				var testValue = Decimal64.FromDoubleRounded(inputValue);
+				if (refValue != testValue)
+					throw new Exception("The inputValue(=Double.longBitsToDouble(" +
+						BitConverter.DoubleToInt64Bits(inputValue) + "L) case error: refValue(=" + refValue + "L) != testValue(=" + testValue + ")");
+			}
+		}
+
+		[Test]
+		public void TestFromDoubleRoundedLongAlias()
+		{
+			Random random = new Random();
+			var roundingModeValues = Enum.GetValues(typeof(RoundingMode));
+			int roundingModeLength = roundingModeValues.Length - 1;
+			for (int i = 0; i < N; ++i)
+			{
+				double inputValue = random.NextDouble() * random.Next(-20, 20);
+				int n = random.Next(-20, 20);
+				RoundingMode mode = (RoundingMode)roundingModeValues.GetValue(random.Next(roundingModeLength));
+
+				var refValue = Decimal64.FromDouble(inputValue).Round(n, mode);
+				var testValue = Decimal64.FromDoubleRounded(inputValue, n, mode);
+				if (refValue != testValue)
+					throw new Exception("The inputValue(=Double.longBitsToDouble(" +
+						BitConverter.DoubleToInt64Bits(inputValue) + "L) n(=" + n + ") mode(=" + mode +
+						")  case error: refValue(=" + refValue + "L) != testValue(=" + testValue + ")");
+			}
+		}
 
 		static void Main()
 		{

--- a/csharp/EPAM.Deltix.DFP/Decimal64.cs
+++ b/csharp/EPAM.Deltix.DFP/Decimal64.cs
@@ -196,6 +196,20 @@ namespace EPAM.Deltix.DFP
 			return new Decimal64(NativeImpl.fromFloat64(value));
 		}
 
+		public static readonly int FromDoubleRoundedDefaultPrecision = 12;
+		public static readonly RoundingMode FromDoubleRoundedDefaultRounding = RoundingMode.HalfUp;
+
+		public static Decimal64 FromDoubleRounded(double value)
+		{
+			return FromDoubleRounded(value, FromDoubleRoundedDefaultPrecision, FromDoubleRoundedDefaultRounding);
+		}
+
+		public static Decimal64 FromDoubleRounded(double value, int n, RoundingMode roundType)
+		{
+			return FromDouble(value).Round(n, roundType);
+		}
+
+
 		public static Decimal64 FromDecimalDouble(Double value)
 		{
 			return new Decimal64(DotNetImpl.FromDecimalFloat64(value));

--- a/csharp/EPAM.Deltix.DFP/Decimal64.cs
+++ b/csharp/EPAM.Deltix.DFP/Decimal64.cs
@@ -209,7 +209,6 @@ namespace EPAM.Deltix.DFP
 			return FromDouble(value).Round(n, roundType);
 		}
 
-
 		public static Decimal64 FromDecimalDouble(Double value)
 		{
 			return new Decimal64(DotNetImpl.FromDecimalFloat64(value));

--- a/java/dfp/src/main/java/com/epam/deltix/dfp/Decimal64.java
+++ b/java/dfp/src/main/java/com/epam/deltix/dfp/Decimal64.java
@@ -236,6 +236,36 @@ public class Decimal64 extends Number implements Comparable<Decimal64> {
     }
 
     /**
+     * Create {@code Decimal64} instance from 64-bit binary floating point ({@code double}) value
+     * rounded according the {@code Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION} precision
+     * and {@code Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING} rounding type.
+     * This is a same as
+     * {@code Decimal64.fromDouble(value).round(Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION, Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING)} call.
+     *
+     * @param value source 64-bit binary floating point value
+     * @return new {@code Decimal64} converted and rounded instance
+     */
+    @Decimal
+    public static Decimal64 fromDoubleRounded(final double value) {
+        return new Decimal64(Decimal64Utils.fromDoubleRounded(value));
+    }
+
+    /**
+     * Create {@code Decimal64} instance from 64-bit binary floating point ({@code double}) value
+     * rounded according the selected rounding type and precision.
+     * This is a same as {@code Decimal64.fromDouble(value).round(n, roundType)} call.
+     *
+     * @param value     source 64-bit binary floating point value
+     * @param n         the number of decimals to use when rounding the number
+     * @param roundType {@code RoundingMode} type of rounding
+     * @return new {@code Decimal64} converted and rounded instance
+     */
+    @Decimal
+    public static Decimal64 fromDoubleRounded(final double value, final int n, final RoundingMode roundType) {
+        return new Decimal64(Decimal64Utils.fromDoubleRounded(value, n, roundType));
+    }
+
+    /**
      * Convert {@code Decimal64} instance to 64-bit binary floating point ({@code double}) value.
      * <p>Note that not all decimal FP values can be exactly represented as binary FP values.
      *

--- a/java/dfp/src/main/java/com/epam/deltix/dfp/Decimal64Utils.java
+++ b/java/dfp/src/main/java/com/epam/deltix/dfp/Decimal64Utils.java
@@ -422,6 +422,39 @@ public class Decimal64Utils {
         return JavaImplCastBinary64.binary64_to_bid64(value, BID_ROUNDING_TO_NEAREST);
     }
 
+    public static int FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION = 12;
+    public static RoundingMode FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Create {@code DFP} value from 64-bit binary floating point ({@code double}) value
+     * rounded according the {@code FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION} precision and
+     * {@code FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING} rounding type.
+     * This is just an alias to the
+     * {@code fromDoubleRounded(value, FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION, FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING)} call.
+     *
+     * @param value source 64-bit binary floating point value
+     * @return {@code DFP} converted and rounded value
+     */
+    @Decimal
+    public static long fromDoubleRounded(final double value) {
+        return fromDoubleRounded(value, FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION, FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING);
+    }
+
+    /**
+     * Create {@code DFP} value from 64-bit binary floating point ({@code double}) value
+     * rounded according the selected rounding type and precision.
+     * This is just an alias to the {@code round(fromDouble(value), n, roundType)} call.
+     *
+     * @param value     source 64-bit binary floating point value
+     * @param n         the number of decimals to use when rounding the number
+     * @param roundType {@code RoundingMode} type of rounding
+     * @return {@code DFP} converted and rounded value
+     */
+    @Decimal
+    public static long fromDoubleRounded(final double value, final int n, final RoundingMode roundType) {
+        return round(fromDouble(value), n, roundType);
+    }
+
     /**
      * Convert {@code DFP} value to 64-bit binary floating point ({@code double}) value.
      * <p>Note that not all decimal FP values can be exactly represented as binary FP values.

--- a/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
+++ b/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
@@ -4,7 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.security.SecureRandom;
+import java.math.RoundingMode;
 import java.util.Random;
 
 import static com.epam.deltix.dfp.TestUtils.*;
@@ -210,4 +210,37 @@ public class FromDoubleTest {
     }
 
     static final int N = 5000000;
+
+    @Test
+    public void testFromDoubleRoundedShortAlias() {
+        final Random random = new Random();
+        for (int i = 0; i < N; ++i) {
+            final double inputValue = random.nextDouble() * random.nextInt(-20, 20);
+            final long ref = Decimal64Utils.round(Decimal64Utils.fromDouble(inputValue),
+                Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION,
+                Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING);
+            final long test = Decimal64Utils.fromDoubleRounded(inputValue);
+            if (ref != test)
+                throw new RuntimeException("The inputValue(=Double.longBitsToDouble(" +
+                    Double.doubleToRawLongBits(inputValue) + "L) case error: ref(=" + ref + "L) != test(=" + test + ")");
+        }
+    }
+
+    @Test
+    public void testFromDoubleRoundedLongAlias() {
+        final Random random = new Random();
+        final int roundingModeLength = RoundingMode.values().length - 1;
+        for (int i = 0; i < N; ++i) {
+            final double inputValue = random.nextDouble() * random.nextInt(-20, 20);
+            final int n = random.nextInt(-20, 20);
+            final RoundingMode mode = RoundingMode.valueOf(random.nextInt(roundingModeLength));
+
+            final long ref = Decimal64Utils.round(Decimal64Utils.fromDouble(inputValue), n, mode);
+            final long test = Decimal64Utils.fromDoubleRounded(inputValue, n, mode);
+            if (ref != test)
+                throw new RuntimeException("The inputValue(=Double.longBitsToDouble(" +
+                    Double.doubleToRawLongBits(inputValue) + "L) n(=" + n + ") mode(=" + mode +
+                    ")  case error: ref(=" + ref + "L) != test(=" + test + ")");
+        }
+    }
 }

--- a/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
+++ b/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
@@ -232,7 +232,7 @@ public class FromDoubleTest {
         final int roundingModeLength = RoundingMode.values().length - 1;
         for (int i = 0; i < N; ++i) {
             final double inputValue = random.nextDouble() * (random.nextInt(40) - 20);
-            final int n = random.nextInt(-20, 20);
+            final int n = random.nextInt(40) - 20;
             final RoundingMode mode = RoundingMode.valueOf(random.nextInt(roundingModeLength));
 
             final long ref = Decimal64Utils.round(Decimal64Utils.fromDouble(inputValue), n, mode);

--- a/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
+++ b/java/dfp/src/test/java/com/epam/deltix/dfp/FromDoubleTest.java
@@ -215,7 +215,7 @@ public class FromDoubleTest {
     public void testFromDoubleRoundedShortAlias() {
         final Random random = new Random();
         for (int i = 0; i < N; ++i) {
-            final double inputValue = random.nextDouble() * random.nextInt(-20, 20);
+            final double inputValue = random.nextDouble() * (random.nextInt(40) - 20);
             final long ref = Decimal64Utils.round(Decimal64Utils.fromDouble(inputValue),
                 Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION,
                 Decimal64Utils.FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING);
@@ -231,7 +231,7 @@ public class FromDoubleTest {
         final Random random = new Random();
         final int roundingModeLength = RoundingMode.values().length - 1;
         for (int i = 0; i < N; ++i) {
-            final double inputValue = random.nextDouble() * random.nextInt(-20, 20);
+            final double inputValue = random.nextDouble() * (random.nextInt(40) - 20);
             final int n = random.nextInt(-20, 20);
             final RoundingMode mode = RoundingMode.valueOf(random.nextInt(roundingModeLength));
 


### PR DESCRIPTION
The new function `fromDoubleRounded()` is just an alias to the two calls:
`fromDoubleRounded(value, n, roundType) => round(fromDouble(value), n, roundType)`

Also the simplified version is also added:
`fromDoubleRounded(value) => fromDoubleRounded(value,`
`      FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION,`
`      FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING)`

Right now the default values are:
`    public static int FROM_DOUBLE_ROUNDED_DEFAULT_PRECISION = 12;`
`    public static RoundingMode FROM_DOUBLE_ROUNDED_DEFAULT_ROUNDING = RoundingMode.HALF_UP;`
